### PR TITLE
Switch to 4.x compat version

### DIFF
--- a/com.obsproject.Studio.Plugin.WebSocket.metainfo.xml
+++ b/com.obsproject.Studio.Plugin.WebSocket.metainfo.xml
@@ -2,9 +2,9 @@
 <component type="addon">
   <id>com.obsproject.Studio.Plugin.WebSocket</id>
   <extends>com.obsproject.Studio</extends>
-  <name>WebSocket Plugin</name>
+  <name>WebSocket Server 4.x Compat Plugin</name>
   <summary>Remote-control OBS Studio through WebSockets</summary>
-  <url type="homepage">https://github.com/Palakis/obs-websocket</url>
+  <url type="homepage">https://github.com/obsproject/obs-websocket</url>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0</project_license>
 </component>

--- a/com.obsproject.Studio.Plugin.WebSocket.yaml
+++ b/com.obsproject.Studio.Plugin.WebSocket.yaml
@@ -2,7 +2,7 @@ id: com.obsproject.Studio.Plugin.WebSocket
 branch: stable
 runtime: com.obsproject.Studio
 runtime-version: stable
-sdk: org.kde.Sdk//5.15-21.08
+sdk: org.kde.Sdk//6.3
 build-extension: true
 separate-locales: false
 appstream-compose: false
@@ -13,13 +13,13 @@ modules:
     buildsystem: cmake-ninja
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release
-      - -DLIBOBS_INCLUDE_DIR=/app/include/obs
+      - -DLINUX_PORTABLE=OFF
     post-install:
       - install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo ${FLATPAK_ID}.metainfo.xml
       - appstream-compose --basename=${FLATPAK_ID} --prefix=${FLATPAK_DEST} --origin=flatpak ${FLATPAK_ID}
     sources:
       - type: git
-        url: https://github.com/Palakis/obs-websocket.git
-        commit: d05ff26930d3e2390b69c60c96cbb064dae93d19
+        url: https://github.com/obsproject/obs-websocket.git
+        commit: f7451d82a6b8c82dcf4a94d9b2d80d79ac85542e
       - type: file
         path: com.obsproject.Studio.Plugin.WebSocket.metainfo.xml


### PR DESCRIPTION
OBS Studio 28 provides obs-websocket 5 as a first-party plugin.

Providing the compat version could allow some user to continue to use
software based on 4.x version.

The same should be done to the beta branch to.