### PR TITLE
Update to KDE SDK 6.6

### DIFF
--- a/com.obsproject.Studio.Plugin.WebSocket.yaml
+++ b/com.obsproject.Studio.Plugin.WebSocket.yaml
@@ -2,7 +2,7 @@ id: com.obsproject.Studio.Plugin.WebSocket
 branch: stable
 runtime: com.obsproject.Studio
 runtime-version: stable
-sdk: org.kde.Sdk//6.4
+sdk: org.kde.Sdk//6.6
 build-extension: true
 separate-locales: false
 appstream-compose: false


### PR DESCRIPTION
OBS Studio 30.2.0 is built against org.kde.Sdk 6.6 and can no longer load flatpak extensions built against earlier versions.

Changes from KDE 6.4 > 6.6.

Fixes: https://github.com/flathub/com.obsproject.Studio.Plugin.WebSocket/issues/6